### PR TITLE
Default to display rather than console if running on macOS

### DIFF
--- a/build/rules.mk
+++ b/build/rules.mk
@@ -108,7 +108,9 @@ INFERRED_QEMU := $(shell if which qemu-system-x86_64 2>/dev/null | grep ^/ >/dev
 	elif grep 16 /etc/fedora-release >/dev/null 2>&1; \
 	then echo qemu; else echo qemu-system-x86_64; fi)
 QEMU ?= $(INFERRED_QEMU)
+ifneq ($(strip $(shell uname)),Darwin)
 QEMUCONSOLE ?= $(if $(DISPLAY),,1)
+endif
 QEMUDISPLAY ?= $(if $(QEMUCONSOLE),console,graphic)
 
 $(OBJDIR)/libqemu-nograb.so.1: build/qemu-nograb.c


### PR DESCRIPTION
The test for starting in a display instead of the console is based on whether the $(DISPLAY) environment variable is set (typically by the X Window System). Yet on macOS (Darwin) we have a GUI without $(DISPLAY) being set. This change says that if we are on Darwin then we can use a graphic window.