### PR TITLE
Allow debugging of boot code

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -227,6 +227,13 @@ run-gdb-graphic: $(QEMUIMAGEFILES) check-qemu
 	$(call run,sleep 0.5; gdb -x build/chickadee.gdb,GDB)
 run-gdb-console: $(QEMUIMAGEFILES) check-qemu-console
 	$(call run,$(QEMU) $(QEMUOPT) -curses -gdb tcp::12949 $(QEMUIMG),QEMU $<)
+run-gdb-paused: run-gdb-$(QEMUDISPLAY)
+	@:
+run-gdb-graphic-paused: $(QEMUIMAGEFILES) check-qemu
+	$(call run,$(QEMU_PRELOAD) $(QEMU) $(QEMUOPT) -S -gdb tcp::12949 $(QEMUIMG) &,QEMU $<)
+	$(call run,sleep 0.5; gdb -x build/chickadee.gdb,GDB)
+run-gdb-console-paused: $(QEMUIMAGEFILES) check-qemu-console
+	$(call run,$(QEMU) $(QEMUOPT) -curses -S -gdb tcp::12949 $(QEMUIMG),QEMU $<)
 
 run-$(RUNSUFFIX): run
 run-graphic-$(RUNSUFFIX): run-graphic

--- a/p-allocator.cc
+++ b/p-allocator.cc
@@ -10,8 +10,11 @@ void process_main() {
     sys_kdisplay(KDISPLAY_MEMVIEWER);
 
     // Fork three new copies. (But ignore failures.)
-    (void) sys_fork();
-    (void) sys_fork();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+    pid_t pid1 = sys_fork();
+    pid_t pid2 = sys_fork();
+#pragma GCC diagnostic pop
 
     pid_t p = sys_getpid();
     srand(p);


### PR DESCRIPTION
I would like to be able to start the emulator in a [paused state](https://qemu.weilnetz.de/doc/qemu-doc.html#Managed-start-up-options) so I can step through the boot process. This commit modifies the start scripts so that when using the debugger we can set breakpoints before the boot process starts.

You previously [suggested](https://github.com/CS161/chickadee/pull/4) that this be a separate option.