### PR TITLE
Add ability to start paused so we can debug the startup process

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -227,6 +227,13 @@ run-gdb-graphic: $(QEMUIMAGEFILES) check-qemu
 	$(call run,sleep 0.5; gdb -x build/chickadee.gdb,GDB)
 run-gdb-console: $(QEMUIMAGEFILES) check-qemu-console
 	$(call run,$(QEMU) $(QEMUOPT) -curses -gdb tcp::12949 $(QEMUIMG),QEMU $<)
+run-gdb-paused: run-gdb-$(QEMUDISPLAY)
+	@:
+run-gdb-graphic-paused: $(QEMUIMAGEFILES) check-qemu
+	$(call run,$(QEMU_PRELOAD) $(QEMU) $(QEMUOPT) -S -gdb tcp::12949 $(QEMUIMG) &,QEMU $<)
+	$(call run,sleep 0.5; gdb -x build/chickadee.gdb,GDB)
+run-gdb-console-paused: $(QEMUIMAGEFILES) check-qemu-console
+	$(call run,$(QEMU) $(QEMUOPT) -curses -S -gdb tcp::12949 $(QEMUIMG),QEMU $<)
 
 run-$(RUNSUFFIX): run
 run-graphic-$(RUNSUFFIX): run-graphic

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -227,12 +227,12 @@ run-gdb-graphic: $(QEMUIMAGEFILES) check-qemu
 	$(call run,sleep 0.5; gdb -x build/chickadee.gdb,GDB)
 run-gdb-console: $(QEMUIMAGEFILES) check-qemu-console
 	$(call run,$(QEMU) $(QEMUOPT) -curses -gdb tcp::12949 $(QEMUIMG),QEMU $<)
-run-gdb-paused: run-gdb-$(QEMUDISPLAY)
+run-gdb-paused: run-gdb-paused-$(QEMUDISPLAY)
 	@:
-run-gdb-graphic-paused: $(QEMUIMAGEFILES) check-qemu
+run-gdb-paused-graphic: $(QEMUIMAGEFILES) check-qemu
 	$(call run,$(QEMU_PRELOAD) $(QEMU) $(QEMUOPT) -S -gdb tcp::12949 $(QEMUIMG) &,QEMU $<)
 	$(call run,sleep 0.5; gdb -x build/chickadee.gdb,GDB)
-run-gdb-console-paused: $(QEMUIMAGEFILES) check-qemu-console
+run-gdb-paused-console: $(QEMUIMAGEFILES) check-qemu-console
 	$(call run,$(QEMU) $(QEMUOPT) -curses -S -gdb tcp::12949 $(QEMUIMG),QEMU $<)
 
 run-$(RUNSUFFIX): run
@@ -242,6 +242,9 @@ run-monitor-$(RUNSUFFIX): run-monitor
 run-gdb-$(RUNSUFFIX): run-gdb
 run-gdb-graphic-$(RUNSUFFIX): run-gdb-graphic
 run-gdb-console-$(RUNSUFFIX): run-gdb-console
+run-gdb-paused-$(RUNSUFFIX): run-gdb-paused
+run-gdb-paused-graphic-$(RUNSUFFIX): run-gdb-paused-graphic
+run-gdb-paused-console-$(RUNSUFFIX): run-gdb-paused-console
 
 # Kill all my qemus
 kill:


### PR DESCRIPTION
I would like to be able to start the emulator in a [paused state](https://qemu.weilnetz.de/doc/qemu-doc.html#Managed-start-up-options) so I can step through the boot process. This commit modifies the start scripts so that when using the debugger we can set breakpoints before the boot process starts.

You previously [suggested](https://github.com/CS161/chickadee/pull/4) that this be a separate option.