### PR TITLE
README.md and build artifacts

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -186,13 +186,17 @@ $(OBJDIR)/chickadeefsck: $(CHICKADEEFSCK_OBJS) $(BUILDSTAMPS)
 # How to make disk images
 
 # If you change the `-f` argument, also change `boot.cc:KERNEL_START_SECTOR`
-chickadeeboot.img: $(OBJDIR)/mkchickadeefs $(OBJDIR)/bootsector $(OBJDIR)/kernel
-	$(call run,$(OBJDIR)/mkchickadeefs -b 4096 -f 16 -s $(OBJDIR)/bootsector $(OBJDIR)/kernel > $@,CREATE $@)
+# The following two items have been formatted to highlight their similarities
+chickadeeboot.img: $(OBJDIR)/mkchickadeefs \
+	$(OBJDIR)/bootsector $(OBJDIR)/kernel
+	$(call run,$(OBJDIR)/mkchickadeefs -b  4096 -f 16       -s \
+	$(OBJDIR)/bootsector $(OBJDIR)/kernel                    > $@,CREATE $@)
 
-chickadeefs.img: $(OBJDIR)/mkchickadeefs \
-	$(OBJDIR)/bootsector $(OBJDIR)/kernel $(DISKFS_CONTENTS) \
-	$(DISKFS_BUILDSTAMP)
-	$(call run,$(OBJDIR)/mkchickadeefs -b 32768 -f 16 -j 64 -s $(OBJDIR)/bootsector $(OBJDIR)/kernel $(DISKFS_CONTENTS) > $@,CREATE $@)
+chickadeefs.img:   $(OBJDIR)/mkchickadeefs \
+	$(OBJDIR)/bootsector $(OBJDIR)/kernel \
+	$(DISKFS_CONTENTS) $(DISKFS_BUILDSTAMP)
+	$(call run,$(OBJDIR)/mkchickadeefs -b 32768 -f 16 -j 64 -s \
+	$(OBJDIR)/bootsector $(OBJDIR)/kernel $(DISKFS_CONTENTS) > $@,CREATE $@)
 
 cleanfs:
 	$(call run,rm -f chickadeefs.img,RM chickadeefs.img)

--- a/README.md
+++ b/README.md
@@ -98,13 +98,14 @@ Source files
 Build files
 -----------
 
-The main output of the build process is a disk image,
-`chickadeeos.img`. QEMU “boots” off this disk image, but the image
-could conceivably boot on real hardware! The build process also
+The main outputs of the build process are two disk images, `chickadeeboot.img` and 
+`chickadeefs.img`. QEMU “boots” off a disk image, but the image
+could conceivably boot on real hardware! The build process relies on and
 produces other files that can be useful to examine.
 
 | File                         | Description                          |
 | ---------------------------- | ------------------------------------ |
+| `GNUmakefile`                | Instructions on how to build things  |
 | `obj/kernel.asm`             | Kernel assembly (with addresses)     |
 | `obj/kernel.sym`             | Kernel defined symbols               |
 | `obj/p-allocator.asm`, `sym` | Same for process binaries            |


### PR DESCRIPTION
Correct the names of the disk images in README.md and reformat how the disk images are created to highlight their similarities and differences.